### PR TITLE
Dan/support prev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_size = 4
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*]
 indent_size = 4
-indent_style = tab
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode-test/
 *.vsix
+out

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["editorconfig.editorconfig"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
-			]
+			],
+			"preLaunchTask": "npm: compile"
 		}
 	]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
 .vscode/**
 .gitignore
 **/jsconfig.json
+out

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 This extension adds the following commands to VSCode.
 
+- `Go to Previous Problem (Error)`
 - `Go to Next Problem (Error)`
 - `Go to Next Problem in Files (Error)`
+- `Go to Previous Problem (Error, Warning)`
 - `Go to Next Problem (Error, Warning)`
 - `Go to Next Problem in Files (Error, Warning)`
 
-These commands are like the VSCode's built-in `Go to Next Problem (Error, Warning, Info)` and `Go to Next Problem in Files (Error, Warning, Info)`, but they select only markers of the specified severity.
+These commands are like the VSCode's built-in `Go to Previous/Next Problem (Error, Warning, Info)` and `Go to Next Problem in Files (Error, Warning, Info)`, but they select only markers of the specified severity.
 
 ---
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,9 +1,0 @@
-{
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "ESNext",
-		"checkJs": true,
-		"strict": true
-	},
-	"exclude": ["node_modules"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "go-to-next-error",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "go-to-next-error",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"devDependencies": {
 				"@types/node": "^17.0.33",
-				"@types/vscode": "^1.57.0"
+				"@types/vscode": "^1.57.0",
+				"typescript": "^5.0.4"
 			},
 			"engines": {
 				"vscode": "^1.57.0"
@@ -26,6 +27,19 @@
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
 			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
 			"dev": true
+		},
+		"node_modules/typescript": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=12.20"
+			}
 		}
 	},
 	"dependencies": {
@@ -39,6 +53,12 @@
 			"version": "1.67.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
 			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
 		"problem",
 		"marker"
 	],
-	"main": "./extension.js",
-	"browser": "./extension.js",
+	"main": "./out/extension.js",
+	"browser": "./out/extension.js",
 	"contributes": {
 		"commands": [
 			{
@@ -62,8 +62,14 @@
 			"supported": true
 		}
 	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./"
+	},
 	"devDependencies": {
 		"@types/node": "^17.0.33",
-		"@types/vscode": "^1.57.0"
+		"@types/vscode": "^1.57.0",
+		"typescript": "^5.0.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
 	"activationEvents": [
 		"onCommand:go-to-next-error.nextInFiles.error",
 		"onCommand:go-to-next-error.next.error",
+		"onCommand:go-to-next-error.prev.error",
 		"onCommand:go-to-next-error.nextInFiles.warning",
-		"onCommand:go-to-next-error.next.warning"
+		"onCommand:go-to-next-error.next.warning",
+		"onCommand:go-to-next-error.prev.warning"
 	],
 	"keywords": [
 		"error",
@@ -47,12 +49,20 @@
 				"title": "Go to Next Problem (Error)"
 			},
 			{
+				"command": "go-to-next-error.prev.error",
+				"title": "Go to Previous Problem (Error)"
+			},
+			{
 				"command": "go-to-next-error.nextInFiles.warning",
 				"title": "Go to Next Problem in Files (Error, Warning)"
 			},
 			{
 				"command": "go-to-next-error.next.warning",
 				"title": "Go to Next Problem (Error, Warning)"
+			},
+			{
+				"command": "go-to-next-error.prev.warning",
+				"title": "Go to Previous Problem (Error, Warning)"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,16 +1,15 @@
-import * as vscode from 'vscode'
+import * as vscode from "vscode"
 
 export const activate = (context: vscode.ExtensionContext) => {
-    let lastPosition: { uri: vscode.Uri, position:vscode.Position } | null = null
+    let lastPosition: { uri: vscode.Uri, position: vscode.Position } | null = null
 
     const getMarkersSorted = (diagnostics: vscode.Diagnostic[]) =>
         diagnostics.sort((a, b) => a.range.start.isBefore(b.range.start) ? -1 : (a.range.start.isEqual(b.range.start) ? 0 : 1))
-    
 
     const getCloserPrev = (editor: vscode.TextEditor, currentMarker: vscode.Diagnostic, soFarClosest: vscode.Diagnostic | null) => {
         if (currentMarker.range.start.isBeforeOrEqual(editor.selection.start) && // Select only errors before the cursor.
             (soFarClosest === null || currentMarker.range.start.isAfter(soFarClosest.range.start)) // Select the error closest to the cursor.
-        ) { 
+        ) {
             return currentMarker;
         }
         return soFarClosest;
@@ -19,7 +18,7 @@ export const activate = (context: vscode.ExtensionContext) => {
     const getCloserNext = (editor: vscode.TextEditor, currentMarker: vscode.Diagnostic, soFarClosest: vscode.Diagnostic | null) => {
         if (currentMarker.range.start.isAfterOrEqual(editor.selection.start) && // Select only errors before the cursor.
             (soFarClosest === null || currentMarker.range.start.isBefore(soFarClosest.range.start)) // Select the error closest to the cursor.
-        ) { 
+        ) {
             return currentMarker;
         }
         return soFarClosest;
@@ -29,7 +28,7 @@ export const activate = (context: vscode.ExtensionContext) => {
      * Selects the next error in the active file.
      * Returns false if loop = false and there are no errors after the cursor.
      */
-    const gotoMarkerInFile = async (filter: vscode.DiagnosticSeverity[], direction: 'next' | 'prev', loop = true) => {
+    const gotoMarkerInFile = async (filter: vscode.DiagnosticSeverity[], direction: "next" | "prev", loop = true) => {
         const editor = vscode.window.activeTextEditor
         if (editor === undefined) { return false }
         const diagnostics = vscode.languages.getDiagnostics(editor.document.uri)
@@ -46,14 +45,14 @@ export const activate = (context: vscode.ExtensionContext) => {
                 continue;
             }
 
-            next = direction === 'next'
+            next = direction === "next"
                 ? getCloserNext(editor, d, next)
                 : getCloserPrev(editor, d, next)
         }
 
         if (next === null && loop) {
             const sortedMarkers = getMarkersSorted(diagnostics)
-            next = direction === 'next' ? sortedMarkers[0] : sortedMarkers[sortedMarkers.length - 1]
+            next = direction === "next" ? sortedMarkers[0] : sortedMarkers[sortedMarkers.length - 1]
 
             // Fix: When there is only one error location in the file, multiple command calls will select a non-error marker.
             if (lastPosition !== null &&
@@ -75,7 +74,7 @@ export const activate = (context: vscode.ExtensionContext) => {
 
     const gotoNextMarkerInFiles = async (filter: vscode.DiagnosticSeverity[]) => {
         // If there is an error after the cursor in the file, select it.
-        if (await gotoMarkerInFile(filter, 'next', false)) { return }
+        if (await gotoMarkerInFile(filter, "next", false)) { return }
 
         // Get the first error in the next document.
         const filesSorted = vscode.languages.getDiagnostics()
@@ -87,7 +86,7 @@ export const activate = (context: vscode.ExtensionContext) => {
         if (filesSorted.length === 0) { return }
         if (filesSorted.length === 1 && filesSorted[0][0].toString() === vscode.window.activeTextEditor?.document.uri.toString()) {
             // Fix: When there is only one error location in all files, multiple command calls will select a non-error marker.
-            await gotoMarkerInFile(filter, 'next', true)
+            await gotoMarkerInFile(filter, "next", true)
             return
         }
 
@@ -105,11 +104,11 @@ export const activate = (context: vscode.ExtensionContext) => {
     }
 
     context.subscriptions.push(
-        vscode.commands.registerCommand("go-to-next-error.next.error", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error], 'next')),
-        vscode.commands.registerCommand("go-to-next-error.prev.error", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error], 'prev')),
+        vscode.commands.registerCommand("go-to-next-error.next.error", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error], "next")),
+        vscode.commands.registerCommand("go-to-next-error.prev.error", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error], "prev")),
         vscode.commands.registerCommand("go-to-next-error.nextInFiles.error", () => gotoNextMarkerInFiles([vscode.DiagnosticSeverity.Error])),
-        vscode.commands.registerCommand("go-to-next-error.next.warning", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error, vscode.DiagnosticSeverity.Warning], 'next')),
-        vscode.commands.registerCommand("go-to-next-error.prev.warning", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error, vscode.DiagnosticSeverity.Warning], 'prev')),
+        vscode.commands.registerCommand("go-to-next-error.next.warning", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error, vscode.DiagnosticSeverity.Warning], "next")),
+        vscode.commands.registerCommand("go-to-next-error.prev.warning", () => gotoMarkerInFile([vscode.DiagnosticSeverity.Error, vscode.DiagnosticSeverity.Warning], "prev")),
         vscode.commands.registerCommand("go-to-next-error.nextInFiles.warning", () => gotoNextMarkerInFiles([vscode.DiagnosticSeverity.Error, vscode.DiagnosticSeverity.Warning])),
     )
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,16 @@
-const vscode = require("vscode")
+import * as vscode from 'vscode'
 
-exports.activate = (/** @type {vscode.ExtensionContext} */context) => {
-    /** @type {{ uri: vscode.Uri, position:vscode.Position }| null} */
-    let lastPosition = null
+export const activate = (context: vscode.ExtensionContext) => {
+    let lastPosition: { uri: vscode.Uri, position:vscode.Position } | null = null
 
-    const getFirstMarker = (/** @type {vscode.Diagnostic[]} */diagnostics) =>
+    const getFirstMarker = (diagnostics: vscode.Diagnostic[]) =>
         diagnostics.sort((a, b) => a.range.start.isBefore(b.range.start) ? -1 : (a.range.start.isEqual(b.range.start) ? 0 : 1))[0]
 
     /**
      * Selects the next error in the active file.
      * Returns false if loop = false and there are no errors after the cursor.
      */
-    const gotoNextMarkerInFile = async (/** @type {vscode.DiagnosticSeverity[]} */filter, /** @type {boolean} */loop = true) => {
+    const gotoNextMarkerInFile = async (filter: vscode.DiagnosticSeverity[], loop = true) => {
         const editor = vscode.window.activeTextEditor
         if (editor === undefined) { return false }
         const diagnostics = vscode.languages.getDiagnostics(editor.document.uri)
@@ -20,8 +19,7 @@ exports.activate = (/** @type {vscode.ExtensionContext} */context) => {
         if (lastPosition?.uri.toString() !== editor.document.uri.toString()) {
             lastPosition = null
         }
-        /** @type {vscode.Diagnostic | null} */
-        let next = null
+        let next: vscode.Diagnostic | null = null
         if (diagnostics.length === 0) { return false }
 
         for (const d of diagnostics) {
@@ -54,7 +52,7 @@ exports.activate = (/** @type {vscode.ExtensionContext} */context) => {
         return true
     }
 
-    const gotoNextMarkerInFiles = async (/** @type {vscode.DiagnosticSeverity[]} */filter) => {
+    const gotoNextMarkerInFiles = async (filter: vscode.DiagnosticSeverity[]) => {
         // If there is an error after the cursor in the file, select it.
         if (await gotoNextMarkerInFile(filter, false)) { return }
 
@@ -93,4 +91,4 @@ exports.activate = (/** @type {vscode.ExtensionContext} */context) => {
     )
 }
 
-exports.deactivate = () => { }
+export const deactivate = () => { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "ES2020",
+		"outDir": "out",
+		"lib": ["ES2020"],
+		"sourceMap": true,
+		"rootDir": "src",
+		"strict": true /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	}
+}


### PR DESCRIPTION
Implements https://github.com/yy0931/go-to-next-error/issues/6

1st Commit switches to TypeScript to make collaboration easier, and is optional. It also contains some basic formatting configuration which prevents formatting hell from happening.

2nd commit introduces goto "previous", but only for current file, not between files. The reason this is missing is that I didn't see much value in implementing it. If you nevertheless need it, it can be added easily.
