### PR TITLE
feat: use editor.action.showHover

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,16 @@ export const activate = (context: vscode.ExtensionContext) => {
         lastPosition = { position: next.range.start, uri: editor.document.uri }
         editor.selection = new vscode.Selection(next.range.start, next.range.start)
         await vscode.commands.executeCommand("closeMarkersNavigation")  // Issue #3
-        await vscode.commands.executeCommand("editor.action.marker.next")
+        
+        const problemInViewport = editor.visibleRanges.every(r => r.contains(editor.selection))
+        const smoothScroll = vscode.workspace.getConfiguration().get('editor.smoothScrolling') as boolean;
+        
+        if (problemInViewport || !smoothScroll) {
+            await vscode.commands.executeCommand("editor.action.showHover")
+        } else {
+            editor.revealRange(next.range);
+            setTimeout(() => vscode.commands.executeCommand("editor.action.showHover"), 150)
+        }
         return true
     }
 


### PR DESCRIPTION
This change has big implications since it stops using `editor.action.marker.next`.

The issue with using markers is that vscode always tries to exhaust one type of markers before it begins marking the other types. So eg. on repeated `editor.action.marker.next` all errors get marked first, even if they are interwoven by warnings in the text editor, and only then warnings start being marked.

This is a direct contradiction to how this extensions works, which navigates based on vertical position, regardless of the issue type, which leads to issues: https://github.com/yy0931/go-to-next-error/issues/8

Since `editor.action.marker.next` is currently not configurable, I decided to use `editor.action.showHover` instead, which triggers documentation, or in case of problems, problem explanations.

Now this approach has following advantages:
1. It's consistent with how this extensions navigates the editor. That means it picks the next nearest problem when triggered and doesn't try to exhaust one type of issues first.
2. When using an extension to prettify problems, like yoavbls.pretty-ts-errors, it applies them, unlike the problem markers which can't do that. This is actually huge for it allows integrations with other plugins.
3. It doesn't scroll needlessly when the problem is already present in the viewport. This makes it work the same way issue navigation works eg. in WebStorm, which many people find superior. See: https://github.com/microsoft/vscode/issues/156782 But even if we don't agree on this option, it can be made configurable! Unlike vscode's markers, this PR allows this easily.
4. When do hover box appears, it doesn't shift the code like the markers do, but instead overlays it, which again simplifies visual navigation.

There are some disadvantages also:
1. The hover box is not as visible as marker widgets.
2. Due to smooth scroll option, I had to implement an ugly timeout for opening the hover box, since there is no way currently to wait for smooth scroll to finish (due to how event dispatch works in vscode). The timeout looks random, but always worked for me on both Win and Mac.

TODOs:
1. Right now this PR doesn't respect `editor.cursorSurroundingLines` so the hover box can exceed it. But it can be done along the line.

![gotoWarningFixed](https://github.com/yy0931/go-to-next-error/assets/34311965/e486a552-3720-4402-9db2-ca02b01074f6)

Fixes: https://github.com/yy0931/go-to-next-error/issues/8
Addresses: https://github.com/microsoft/vscode/issues/156782